### PR TITLE
feat: add inbox rules management tools

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -101,7 +101,11 @@ process.on('uncaughtException', (error) => {
       // SharePoint Tools
       getSharePointFileTool,
       listSharePointFilesTool,
-      resolveSharePointLinkTool
+      resolveSharePointLinkTool,
+      // Rules Tools
+      listRulesTool,
+      createRuleTool,
+      deleteRuleTool,
     } = tools;
 
     console.error('Debug: All required tools extracted successfully');
@@ -295,6 +299,15 @@ process.on('uncaughtException', (error) => {
 
           case 'outlook_resolve_sharepoint_link':
             return await resolveSharePointLinkTool(authManager, args);
+
+          case 'outlook_list_rules':
+            return await listRulesTool(authManager, args);
+
+          case 'outlook_create_rule':
+            return await createRuleTool(authManager, args);
+
+          case 'outlook_delete_rule':
+            return await deleteRuleTool(authManager, args);
 
           default:
             return createProtocolError(

--- a/server/schemas/folderSchemas.js
+++ b/server/schemas/folderSchemas.js
@@ -88,12 +88,73 @@ export const getFolderStatsSchema = {
   },
 };
 
+export const listRulesSchema = {
+  name: 'outlook_list_rules',
+  description: 'List all inbox message rules',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+export const createRuleSchema = {
+  name: 'outlook_create_rule',
+  description: 'Create an inbox message rule to automatically move emails matching sender criteria to a specified folder',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      displayName: {
+        type: 'string',
+        description: 'Name of the rule',
+      },
+      senderContains: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'List of strings to match against sender email address (e.g. ["bizreach"])',
+      },
+      moveToFolder: {
+        type: 'string',
+        description: 'ID of the destination folder',
+      },
+      isEnabled: {
+        type: 'boolean',
+        description: 'Whether the rule is enabled (default: true)',
+        default: true,
+      },
+      sequence: {
+        type: 'number',
+        description: 'Order in which rule is applied (default: 1)',
+        default: 1,
+      },
+    },
+    required: ['displayName', 'senderContains', 'moveToFolder'],
+  },
+};
+
+export const deleteRuleSchema = {
+  name: 'outlook_delete_rule',
+  description: 'Delete an inbox message rule by ID',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      ruleId: {
+        type: 'string',
+        description: 'ID of the rule to delete',
+      },
+    },
+    required: ['ruleId'],
+  },
+};
+
 // Export all folder schemas as an array for easy iteration
 export const folderSchemas = [
   listFoldersSchema,
   createFolderSchema,
   renameFolderSchema,
   getFolderStatsSchema,
+  listRulesSchema,
+  createRuleSchema,
+  deleteRuleSchema,
 ];
 
 // Export mapping for quick lookup
@@ -102,4 +163,7 @@ export const folderSchemaMap = {
   'outlook_create_folder': createFolderSchema,
   'outlook_rename_folder': renameFolderSchema,
   'outlook_get_folder_stats': getFolderStatsSchema,
+  'outlook_list_rules': listRulesSchema,
+  'outlook_create_rule': createRuleSchema,
+  'outlook_delete_rule': deleteRuleSchema,
 };

--- a/server/tools/index.js
+++ b/server/tools/index.js
@@ -67,3 +67,6 @@ export { getRateLimitMetricsTool, resetRateLimitMetricsTool } from './common/rat
 
 // SharePoint tools
 export { getSharePointFileTool, listSharePointFilesTool, resolveSharePointLinkTool } from './sharepoint/getSharePointFile.js';
+
+// Rules tools
+export { listRulesTool, createRuleTool, deleteRuleTool } from './rules/manageRules.js';

--- a/server/tools/rules/manageRules.js
+++ b/server/tools/rules/manageRules.js
@@ -1,0 +1,109 @@
+import { convertErrorToToolError, createValidationError } from '../../utils/mcpErrorResponse.js';
+
+// List all inbox message rules
+export async function listRulesTool(authManager, args) {
+  try {
+    await authManager.ensureAuthenticated();
+    const graphApiClient = authManager.getGraphApiClient();
+
+    const result = await graphApiClient.makeRequest('/me/mailFolders/inbox/messageRules', {}, 'GET');
+    const rules = result.value || [];
+
+    if (rules.length === 0) {
+      return {
+        content: [{ type: 'text', text: 'No inbox rules found.' }],
+      };
+    }
+
+    const summary = rules.map(r => ({
+      id: r.id,
+      displayName: r.displayName,
+      isEnabled: r.isEnabled,
+      sequence: r.sequence,
+      conditions: r.conditions,
+      actions: r.actions,
+    }));
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(summary, null, 2) }],
+    };
+  } catch (error) {
+    return convertErrorToToolError(error, 'Failed to list inbox rules');
+  }
+}
+
+// Create a new inbox message rule
+export async function createRuleTool(authManager, args) {
+  const { displayName, senderContains, moveToFolder, isEnabled = true, sequence = 1 } = args;
+
+  if (!displayName) {
+    return createValidationError('displayName', 'Parameter is required');
+  }
+  if (!senderContains || senderContains.length === 0) {
+    return createValidationError('senderContains', 'At least one sender filter is required');
+  }
+  if (!moveToFolder) {
+    return createValidationError('moveToFolder', 'Parameter is required');
+  }
+
+  try {
+    await authManager.ensureAuthenticated();
+    const graphApiClient = authManager.getGraphApiClient();
+
+    const ruleData = {
+      displayName,
+      sequence,
+      isEnabled,
+      conditions: {
+        senderContains,
+      },
+      actions: {
+        moveToFolder,
+        stopProcessingRules: true,
+      },
+    };
+
+    const result = await graphApiClient.postWithRetry(
+      '/me/mailFolders/inbox/messageRules',
+      ruleData
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Rule "${displayName}" created successfully. Rule ID: ${result.id}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return convertErrorToToolError(error, 'Failed to create inbox rule');
+  }
+}
+
+// Delete an inbox message rule
+export async function deleteRuleTool(authManager, args) {
+  const { ruleId } = args;
+
+  if (!ruleId) {
+    return createValidationError('ruleId', 'Parameter is required');
+  }
+
+  try {
+    await authManager.ensureAuthenticated();
+    const graphApiClient = authManager.getGraphApiClient();
+
+    await graphApiClient.deleteWithRetry(`/me/mailFolders/inbox/messageRules/${ruleId}`);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Rule ${ruleId} deleted successfully.`,
+        },
+      ],
+    };
+  } catch (error) {
+    return convertErrorToToolError(error, 'Failed to delete inbox rule');
+  }
+}

--- a/server/tools/rules/manageRules.js
+++ b/server/tools/rules/manageRules.js
@@ -7,6 +7,12 @@ export async function listRulesTool(authManager, args) {
     const graphApiClient = authManager.getGraphApiClient();
 
     const result = await graphApiClient.makeRequest('/me/mailFolders/inbox/messageRules', {}, 'GET');
+
+    // Propagate MCP error responses returned by makeRequest (e.g. 4xx/5xx from Graph API)
+    if (result.content && result.isError !== undefined) {
+      return result;
+    }
+
     const rules = result.value || [];
 
     if (rules.length === 0) {


### PR DESCRIPTION
## What this adds

Three new MCP tools for managing Outlook inbox message rules via the Microsoft Graph API:

- `outlook_list_rules` — list all existing inbox rules
- `outlook_create_rule` — create a rule that moves emails matching a sender pattern to a specified folder
- `outlook_delete_rule` — delete a rule by ID

## Files changed

- `server/tools/rules/manageRules.js` — new file with all three tool implementations
- `server/schemas/folderSchemas.js` — added schemas for the three tools
- `server/tools/index.js` — exports the new tools
- `server/index.js` — registers the tools in the server dispatcher

## Example usage

```
// Route all GitHub notifications to a folder
outlook_create_rule({
  displayName: "GitHub to GitHub folder",
  senderContains: ["notifications@github.com"],
  moveToFolder: "<folder-id>",
  isEnabled: true
})
```

## Notes

The `createRule` implementation currently only supports sender-based conditions + move-to-folder action, which covers the most common use case. More condition types (subject contains, has attachment, etc.) can be added later without breaking changes.